### PR TITLE
Eliminated cursorline ghosting

### DIFF
--- a/autoload/smooth_scroll.vim
+++ b/autoload/smooth_scroll.vim
@@ -40,9 +40,9 @@ function! s:smooth_scroll(dir, dist, duration, speed)
   for i in range(a:dist/a:speed)
     let start = reltime()
     if a:dir ==# 'd'
-      exec "normal! ".a:speed."\<C-e>".a:speed."j"
+      exec "normal! ".a:speed."j\<C-e>"
     else
-      exec "normal! ".a:speed."\<C-y>".a:speed."k"
+      exec "normal! ".a:speed."k\<C-y>"
     endif
     redraw
     let elapsed = s:get_ms_since(start)


### PR DESCRIPTION
Here is a quick demo of the issue that is fixed in the PR (key sequence in the recording: `<C-f>` followed by `<C-b>` and `j`): ![recorded_demo](http://g.recordit.co/au0eYrz0vZ.gif).
