### PR TITLE
Add error message when speed is zero to prevent division by zero

### DIFF
--- a/autoload/smooth_scroll.vim
+++ b/autoload/smooth_scroll.vim
@@ -37,6 +37,8 @@ endfunction
 " speed: Scrolling speed, or the number of lines to scroll during each scrolling
 " animation
 function! s:smooth_scroll(dir, dist, duration, speed)
+  if a:speed == 0
+    echoerr "Speed argument must not be zero"
   for i in range(a:dist/a:speed)
     let start = reltime()
     if a:dir ==# 'd'


### PR DESCRIPTION
It's potentially dangerous because the next string may lead to overload:
range(a:dist/a:speed)
