### PR TITLE
Fix bug using Float as String

### DIFF
--- a/autoload/smooth_scroll.vim
+++ b/autoload/smooth_scroll.vim
@@ -55,6 +55,7 @@ endfunction
 
 function! s:get_ms_since(time)
   let cost = split(reltimestr(reltime(a:time)), '\.')
-  return str2nr(cost[0])*1000 + str2nr(cost[1])/1000.0
+  return str2nr(cost[0])*1000 + str2nr(cost[1])/1000
 endfunction
+
 


### PR DESCRIPTION
Vim tries to use a Float as String, if we divide with a float in the `get_ms_since` function. 
The plugin runs very slowly/hangs dueto this bug.

The commit inside the pr fixes the above.